### PR TITLE
Fix issues with history forward/back functions.

### DIFF
--- a/exwm-firefox-core.el
+++ b/exwm-firefox-core.el
@@ -172,16 +172,24 @@
 
 ;;; History
 ;;;###autoload
-(defun exwm-firefox-core-history-forward ()
+(defun exwm-firefox-core-history-forward (&optional arg)
   "Forward in history."
-  (interactive)
-  (exwm-input--fake-key 'M-right))
+  (interactive "P")
+  (let ((times (or arg 1)))
+    (dotimes (_ times)
+      (exwm-input--fake-key 'M-right)
+      (when (> times 1)
+        (sit-for .01)))))
 
 ;;;###autoload
-(defun exwm-firefox-core-history-back ()
+(defun exwm-firefox-core-history-back (&optional arg)
   "Back in history."
-  (interactive)
-  (exwm-input--fake-key 'M-left))
+  (interactive "P")
+  (let ((times (or arg 1)))
+    (dotimes (_ times)
+      (exwm-input--fake-key 'M-left)
+      (when (> times 1)
+        (sit-for .01)))))
 
 ;;;###autoload
 (defun exwm-firefox-core-history-sidebar ()


### PR DESCRIPTION
 - Fix incorrect use of `DOTIMES`.  This macro expects the first arg to be `(var times)`, not `times`.  This caused `Wrong type argument: number-or-marker-p, nil` errors when `EXWM-FIREFOX-CORE-HISTORY-BACK` or `EXWM-FIREFOX-CORE-HISTORY-FORWARD` were called.
 - Add a delay when using a prefix to navigate multiple pages.  With no delay, keypresses happen too fast and all but the first are ignored.